### PR TITLE
Make the parser tuple exported

### DIFF
--- a/binaryparse.nim
+++ b/binaryparse.nim
@@ -677,7 +677,7 @@ macro createParser*(name: untyped, paramsAndDef: varargs[untyped]): untyped =
     proc `writerName`(`stream`: Stream, `input`: var `tupleMeat`) =
       var `tmpVar`: int64 = 0
       `writer`
-    let `name` = (get: `readerName`, put: `writerName`)
+    let `name`* = (get: `readerName`, put: `writerName`)
   for p in extraParams:
     result[0][3].add p
 


### PR DESCRIPTION
Very minor change - I wanted to make sure that the (get, put) tuple was exported.  I think I want to make the tuple type exportable as well.  That way, it's easier to use this in a package.

Thought about adding a do_export flag in createParser, but that made things awkward.
Had to specify `do_export=true` or `do_export=false` even when I had a default in the
createParser macro.